### PR TITLE
Add ability to set output without `<script>` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ Then before `</head>` add following code
 ) ?>
 ```
 
+By default this script generated output :
+
+```html
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ga('create', 'UA-XXXXXXXX-X', "auto");
+ga('send', 'pageview');
+ga('set', 'anonymizeIp', true);
+</script>
+```
+
+But sometimes we need the output without `script` tag to combined with `registerJs` or `registerJsFile` as `renderPartial` to add dependency or positioning configuration, you can use *asScript* **false** to disable `script` tag, example :
+
+```php
+<?= $this->registerJs( GATracking::widget([
+    'trackingId' => 'UA-XXXXXXXX-X',
+    'asScript'   => false
+]), \yii\web\View::POS_END
+);?>
+```
+
 ## Advanced usage
 
 ```php

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ ga('set', 'anonymizeIp', true);
 </script>
 ```
 
-But sometimes we need the output without `script` tag to combined with `registerJs` or `registerJsFile` as `renderPartial` to add dependency or positioning configuration, you can use *asScript* **false** to disable `script` tag, example :
+But sometimes we need the output without `script` tag to combined with `registerJs` or `registerJsFile` as `renderPartial` to add dependency or positioning configuration, you can use *omitScriptTag* **true** to disable `script` tag, example :
 
 ```php
 <?= $this->registerJs( GATracking::widget([
-    'trackingId' => 'UA-XXXXXXXX-X',
-    'asScript'   => false
+    'trackingId'      => 'UA-XXXXXXXX-X',
+    'omitScriptTag'   => true
 ]), \yii\web\View::POS_END
 );?>
 ```

--- a/src/widgets/GATracking.php
+++ b/src/widgets/GATracking.php
@@ -20,7 +20,7 @@ class GATracking extends Widget
      * Render <script></script> 
      * @var bool
      */
-    public $asScript = true;
+    public $omitScriptTag = false;
     
     /**
      * The GA tracking ID
@@ -89,7 +89,7 @@ class GATracking extends Widget
         }
 
         $this->_viewParams = [
-            'asScript' => $this->asScript,
+            'omitScriptTag' => $this->omitScriptTag,
             'trackingId' => $this->trackingId,
             'trackingConfig' => $this->trackingConfig,
             'trackingFilename' => $this->_trackingFilename,

--- a/src/widgets/GATracking.php
+++ b/src/widgets/GATracking.php
@@ -15,6 +15,13 @@ use yii\base\Widget;
  */
 class GATracking extends Widget
 {
+    
+    /**
+     * Render <script></script> 
+     * @var bool
+     */
+    public $asScript = true;
+    
     /**
      * The GA tracking ID
      * @var string
@@ -82,6 +89,7 @@ class GATracking extends Widget
         }
 
         $this->_viewParams = [
+            'asScript' => $this->asScript,
             'trackingId' => $this->trackingId,
             'trackingConfig' => $this->trackingConfig,
             'trackingFilename' => $this->_trackingFilename,

--- a/src/widgets/views/tracking.php
+++ b/src/widgets/views/tracking.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * @var boolean $asScript
+ * @var boolean $omitScriptTag
  * @var string  $trackingId
  * @var array   $trackingParams
  * @var array   $tackingPlugins
  */
 ?>
-<?php if($asScript){
+<?php if(!$omitScriptTag){
 	echo '<script>';
 } ?>
     <?= $trackingDebugTraceInit ?>
@@ -23,6 +23,6 @@
     <?php foreach($plugins as $plugin => $options) : ?>
     ga('require', '<?= $plugin ?>', <?= $options ?>);
     <?php endforeach ?>
-<?php if($asScript){
+<?php if(!$omitScriptTag){
 	echo '</script>';
 } ?>

--- a/src/widgets/views/tracking.php
+++ b/src/widgets/views/tracking.php
@@ -1,11 +1,14 @@
 <?php
 /**
+ * @var boolean $asScript
  * @var string  $trackingId
  * @var array   $trackingParams
  * @var array   $tackingPlugins
  */
 ?>
-<script>
+<?php if($asScript){
+	echo '<script>';
+} ?>
     <?= $trackingDebugTraceInit ?>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -20,4 +23,6 @@
     <?php foreach($plugins as $plugin => $options) : ?>
     ga('require', '<?= $plugin ?>', <?= $options ?>);
     <?php endforeach ?>
-</script>
+<?php if($asScript){
+	echo '</script>';
+} ?>


### PR DESCRIPTION
For best practice the script must be loaded before tag body, so all javascript for web user interface is fully loaded first and then load google analytic js, I pull request this changes to handle this. So for old configuration still same and not change with my commit.

What your opinion ?
