### PR TITLE
Allow plugin events to be fired.

### DIFF
--- a/src/widgets/GATracking.php
+++ b/src/widgets/GATracking.php
@@ -59,6 +59,12 @@ class GATracking extends Widget
     public $plugins = [];
 
     /**
+     * Events list
+     * @var array
+     */
+    public $events = [];
+
+    /**
      * GA script filename
      * @var string
      */
@@ -87,6 +93,9 @@ class GATracking extends Widget
         foreach ($this->plugins as $plugin => &$options) {
             $options = json_encode($options);
         }
+        foreach ($this->events as $event => &$options) {
+            $options = json_encode($options);
+        }
 
         $this->_viewParams = [
             'omitScriptTag' => $this->omitScriptTag,
@@ -99,7 +108,8 @@ class GATracking extends Widget
                 // :TODO: Add more params
             ],
             // :TODO: Add availability to configure events
-            'plugins' => $this->plugins
+            'plugins' => $this->plugins,
+            'events' => $this->events
         ];
     }
 

--- a/src/widgets/views/tracking.php
+++ b/src/widgets/views/tracking.php
@@ -3,11 +3,14 @@
  * @var boolean $omitScriptTag
  * @var string  $trackingId
  * @var array   $trackingParams
- * @var array   $tackingPlugins
+ * @var string  $trackingFilename
+ * @var string  $trackingConfig
+ * @var array   $plugins
+ * @var array   $events
  */
 ?>
 <?php if (!$omitScriptTag) {
-    echo '<script>';
+    echo '<script type="text/javascript">';
 } ?>
     <?= $trackingDebugTraceInit ?>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -22,6 +25,9 @@
     <?php endforeach ?>
     <?php foreach($plugins as $plugin => $options) : ?>
     ga('require', '<?= $plugin ?>', <?= $options ?>);
+    <?php endforeach ?>
+    <?php foreach($events as $event => $options) : ?>
+    ga('<?= $event ?>', <?= $options ?>);
     <?php endforeach ?>
 <?php if (!$omitScriptTag) {
     echo '</script>';


### PR DESCRIPTION
Events like:

```
ga('ecommerce:addTransaction', {
  'id': '1234',                     // Transaction ID. Required.
  'affiliation': 'Acme Clothing',   // Affiliation or store name.
  'revenue': '11.99',               // Grand Total.
  'shipping': '5',                  // Shipping.
  'tax': '1.29'                     // Tax.
});
```

With the config:

```
    echo GATracking::widget(
        [
            'trackingId'     => Yii::$app->params['analyticsConfig']['accountid'],
            'trackingConfig' => [
                'allowAnchor' => false
            ],
            'omitScriptTag'  => false,
            'debug'          => true,
            'debugTrace'     => true,
            'anonymizeIp'    => false,
            'plugins'        => [
                'ecommerce'           => 'ecommerce.js',
            ],
            'events'        => [
                'ecommerce:addTransaction' => [
                    'id'          => '1234',                     // Transaction ID. Required.
                    'affiliation' => 'Acme Clothing',   // Affiliation or store name.
                    'revenue'     => '11.99',               // Grand Total.
                    'shipping'    => '5',                  // Shipping.
                    'tax'         => '1.29'                     // Tax.
                ],
                'ecommerce:addItem'        => [
                    'id'       => '1234',                     // Transaction ID. Required.
                    'name'     => 'Fluffy Pink Bunnies',    // Product name. Required.
                    'sku'      => 'DD23444',                 // SKU/code.
                    'category' => 'Party Toys',         // Category or variation.
                    'price'    => '11.99',                 // Unit price.
                    'quantity' => '1'                   // Quantity.
                ],
                'ecommerce:send'           => [ ],
            ],
        ]
    );
```
